### PR TITLE
Minor refactoring

### DIFF
--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -101,6 +101,4 @@ module ActiveRecord
   end
 end
 
-ActiveRecord::Base.class_eval do
-  include ActiveRecord::DelayTouching
-end
+ActiveRecord::Base.include ActiveRecord::DelayTouching


### PR DESCRIPTION
- Use alias_method_chain for the touch method override to allow for easier debugging and knowledge of where the method came from
- Remove class_eval, include the module directly
