### PR TITLE
update touch to support splat signature introduced in ActiveRecord 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Add this line to your application's Gemfile:
 
     gem 'activerecord-delay_touching'
 
+ActiveRecord introduced some changes in version 4.2 that require a different version of this gem. 
+To load this gem for use with ActiveRecord ***prior to version 4.2***, use the following:
+
+	gem 'activerecord-delay_touching', "~> 0.0.1"
+
 And then execute:
 
     $ bundle
@@ -22,6 +27,7 @@ And then execute:
 Or install it yourself:
 
     $ gem install activerecord-delay_touching
+
 
 ## Usage
 

--- a/activerecord-delay_touching.gemspec
+++ b/activerecord-delay_touching.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "activerecord", ">= 3.2"
+  spec.add_dependency             "activerecord", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -6,9 +6,9 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     # Override ActiveRecord::Base#touch.
-    def touch(name = nil)
+    def touch(*names)
       if self.class.delay_touching? && !try(:no_touching?)
-        DelayTouching.add_record(self, name)
+        DelayTouching.add_record(self, names)
         true
       else
         super

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -37,14 +37,25 @@ module ActiveRecord
         @records.present?
       end
 
-      def add_record(record, column)
-        @records[column] += [ record ] unless @already_updated_records[column].include?(record)
+      def add_record(record, *columns)
+        normalize_columns(columns).each do |column|
+          @records[column] += [ record ] unless @already_updated_records[column].include?(record)
+        end
       end
 
       def clear_records
         @records.clear
         @already_updated_records.clear
       end
+
+      private
+
+      def normalize_columns(columns)
+        columns = columns.flatten
+        columns << nil unless columns.any?
+        columns
+      end
+
     end
   end
 end

--- a/lib/activerecord/delay_touching/version.rb
+++ b/lib/activerecord/delay_touching/version.rb
@@ -1,5 +1,5 @@
 module Activerecord
   module DelayTouching
-    VERSION = "0.0.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
ActiveRecord modified the touch method signature in 4.2 to take a splat of column names, rather than the traditional single field name. 
I tried to solve for this in a way that supports both formats, but things got ugly quickly. SO, I've elected to branch the 0.0.1 version to the pre-activerecord-4.2 branch and move forward on master with ~> 4.2 support of ActiveRecord.

resolves issue #3 