### PR TITLE
update touch to support splat signature introduced in ActiveRecord 4.2

### DIFF
--- a/activerecord-delay_touching.gemspec
+++ b/activerecord-delay_touching.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "activerecord", ">= 3.2"
+  spec.add_dependency             "activerecord", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -6,9 +6,9 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     # Override ActiveRecord::Base#touch.
-    def touch(name = nil)
+    def touch(*names)
       if self.class.delay_touching? && !try(:no_touching?)
-        DelayTouching.add_record(self, name)
+        DelayTouching.add_record(self, *names)
         true
       else
         super

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -37,14 +37,18 @@ module ActiveRecord
         @records.present?
       end
 
-      def add_record(record, column)
-        @records[column] += [ record ] unless @already_updated_records[column].include?(record)
+      def add_record(record, *columns)
+        columns << nil if columns.empty? #if no arguments are passed, we will use nil to infer default column
+        columns.each do |column|
+          @records[column] += [ record ] unless @already_updated_records[column].include?(record)
+        end
       end
 
       def clear_records
         @records.clear
         @already_updated_records.clear
       end
+
     end
   end
 end

--- a/lib/activerecord/delay_touching/version.rb
+++ b/lib/activerecord/delay_touching/version.rb
@@ -1,5 +1,5 @@
 module Activerecord
   module DelayTouching
-    VERSION = "0.0.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
ActiveRecord modified the touch method signature in 4.2 to take a splat of column names, rather than the traditional single field name. 
I tried to solve for this in a way that supports both formats, but things got ugly quickly. SO, I've elected to branch the 0.0.1 version to the pre-activerecord-4.2 branch and move forward on master with ~> 4.2 support of ActiveRecord.

resolves issue #3 