### PR TITLE
Fix NoMethodError Exception thrown on try - undefined method `no_touching?'

### DIFF
--- a/activerecord-delay_touching.gemspec
+++ b/activerecord-delay_touching.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "activerecord", ">= 3.2"
+  spec.add_dependency             "activerecord", ">= 3.2", "< 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -7,7 +7,7 @@ module ActiveRecord
 
     # Override ActiveRecord::Base#touch.
     def touch(name = nil)
-      if self.class.delay_touching? && !try(:no_touching?)
+      if self.class.delay_touching? && !respond_to?(:no_touching?)
         DelayTouching.add_record(self, name)
         true
       else

--- a/lib/activerecord/delay_touching/version.rb
+++ b/lib/activerecord/delay_touching/version.rb
@@ -1,5 +1,5 @@
 module Activerecord
   module DelayTouching
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
On Rails 3.2, the version 0.0.2 (branch pre-activerecord-4.2) is throwing execption
```shell
NoMethodError - undefined method `no_touching?' for #<Scientist:0x00000003b1f870>:
  activemodel (3.2.21) lib/active_model/attribute_methods.rb:407:in `method_missing'
  activerecord (3.2.21) lib/active_record/attribute_methods.rb:149:in `method_missing'
  activesupport (3.2.21) lib/active_support/core_ext/object/try.rb:36:in `try'
  /home/vagrant/src/activerecord-delay_touching/lib/activerecord/delay_touching.rb:10:in `touch'
  activerecord (3.2.21) lib/active_record/associations/builder/belongs_to.rb:59:in `block in add_touch_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `_run__1027536244551054792__destroy__4591310412473624390__callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.21) lib/active_support/callbacks.rb:385:in `_run_destroy_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:81:in `run_callbacks'
```

This pr fixes it.
Thanks