### PR TITLE
Fix NoMethodError Exception thrown on try - undefined method `no_touching?'

### DIFF
--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -7,7 +7,7 @@ module ActiveRecord
 
     # Override ActiveRecord::Base#touch.
     def touch(name = nil)
-      if self.class.delay_touching? && !try(:no_touching?)
+      if self.class.delay_touching? && !respond_to?(:no_touching?)
         DelayTouching.add_record(self, name)
         true
       else


### PR DESCRIPTION
On Rails 3.2, the version 0.0.2 (branch pre-activerecord-4.2) is throwing execption
```shell
NoMethodError - undefined method `no_touching?' for #<Scientist:0x00000003b1f870>:
  activemodel (3.2.21) lib/active_model/attribute_methods.rb:407:in `method_missing'
  activerecord (3.2.21) lib/active_record/attribute_methods.rb:149:in `method_missing'
  activesupport (3.2.21) lib/active_support/core_ext/object/try.rb:36:in `try'
  /home/vagrant/src/activerecord-delay_touching/lib/activerecord/delay_touching.rb:10:in `touch'
  activerecord (3.2.21) lib/active_record/associations/builder/belongs_to.rb:59:in `block in add_touch_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `_run__1027536244551054792__destroy__4591310412473624390__callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.21) lib/active_support/callbacks.rb:385:in `_run_destroy_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:81:in `run_callbacks'
```

This pr fixes it.
Thanks