### PR TITLE
Don't update the record if its being destroyed

### DIFF
--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -86,6 +86,7 @@ module ActiveRecord
           column = column.to_s
           changes[column] = current_time
           records.each do |record|
+            next if record.destroyed?
             record.instance_eval do
               write_attribute column, current_time
               @changed_attributes.except!(*changes.keys)


### PR DESCRIPTION
When a `delay_touching` block is wrapping records that are being destroyed, it tries to `touch` the destroyed records at the end, causing an exception to be raised.

(More specifically, calling [this `write_attribute`](https://github.com/godaddy/activerecord-delay_touching/blob/5f04c35c9d4fb25ebb5eed469dd183e9902831c2/lib/activerecord/delay_touching.rb#L90) on a destroyed record raises a `RuntimeError: Can't modify frozen hash`.)

Consider something like a comment system, where a Comment is on a Post, but also written by a User.  If you destroy a Post, it should take the Comments down with it, but also `touch` the User to bust a cache key or whatever.  If one User wrote 100 Comments on the deleted post, though, we only want the User `touch`ed once.

```ruby
class Post < ActiveRecord::Base
  has_many :comments, dependent: :destroy
end

class User < ActiveRecord::Base
  has_many :comments, dependent: :destroy
end

class Comment < ActiveRecord::Base
  belongs_to :post, touch: true
  belongs_to :user, touch: true
end
```

Here's a bugreport script that shows the issue: https://gist.github.com/tjschuck/ed1368d4cc3a9b0b6f33

Take that file, put it in the root of the project, and run `bundle exec bugreport.rb`

#### Before this change:

```
~/Code/activerecord-delay_touching ☠ bundle exec ruby bugreport.rb
-- create_table(:posts, {:force=>true})
   -> 0.0047s
-- create_table(:users, {:force=>true})
   -> 0.0004s
-- create_table(:comments, {:force=>true})
   -> 0.0005s
Run options: --seed 9443

# Running:

E

Finished in 2.068315s, 0.4835 runs/s, 0.0000 assertions/s.

  1) Error:
BugTest#test_delayed_touch:
RuntimeError: Can't modify frozen hash
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/attribute_set/builder.rb:43:in `[]='
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/attribute_set.rb:39:in `write_from_user'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/attribute_methods/write.rb:74:in `write_attribute_with_type_cast'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/attribute_methods/write.rb:56:in `write_attribute'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/attribute_methods/dirty.rb:96:in `write_attribute'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:90:in `block (3 levels) in touch_records'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:89:in `instance_eval'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:89:in `block (2 levels) in touch_records'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:88:in `each'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:88:in `block in touch_records'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:85:in `each'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:85:in `touch_records'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:67:in `block (3 levels) in apply'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:66:in `each'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:66:in `block (2 levels) in apply'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:65:in `each'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:65:in `block in apply'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
    /Users/tjschuck/.rbenv/versions/2.2.2/gemsets/global/gems/activerecord-4.2.3/lib/active_record/transactions.rb:220:in `transaction'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:64:in `apply'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:54:in `call'
    /Users/tjschuck/Code/activerecord-delay_touching/lib/activerecord/delay_touching.rb:31:in `delay_touching'
    bugreport.rb:52:in `test_delayed_touch'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

#### After:

```
~/Code/activerecord-delay_touching ☠ bundle exec ruby bugreport.rb
-- create_table(:posts, {:force=>true})
   -> 0.0038s
-- create_table(:users, {:force=>true})
   -> 0.0006s
-- create_table(:comments, {:force=>true})
   -> 0.0006s
Run options: --seed 16720

# Running:

.

Finished in 2.055201s, 0.4866 runs/s, 0.4866 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```