### PR TITLE
Issue14 option1

### DIFF
--- a/activerecord-delay_touching.gemspec
+++ b/activerecord-delay_touching.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "activerecord", ">= 4.2"
+  spec.add_dependency             "activerecord", "~> 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "rspec-rails", "~> 2.0"
+  spec.add_development_dependency "rspec-rails", "~> 3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-rcov"
   spec.add_development_dependency "yarjuf"

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -61,7 +61,6 @@ module ActiveRecord
     # Apply the touches that were delayed.
     def self.apply
       begin
-        # If we don't do this then an infinite loop is possible due to how Set#subtract and ActiveRecord::Core#== work
         state.remove_unpersisted_records!
 
         ActiveRecord::Base.transaction do

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -75,6 +75,7 @@ module ActiveRecord
 
     # Touch the specified records--non-empty set of instances of the same class.
     def self.touch_records(attr, klass, records)
+      # If we don't do this then an infinite loop is possible due to how Set#subtract and ActiveRecord::Core#== work
       state.remove_unpersisted_records!
       attributes = records.first.send(:timestamp_attributes_for_update_in_model)
       attributes << attr if attr
@@ -87,6 +88,7 @@ module ActiveRecord
           column = column.to_s
           changes[column] = current_time
           records.each do |record|
+            # Don't bother if destroyed or not-saved
             next unless record.persisted?
             record.instance_eval do
               write_attribute column, current_time

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -60,9 +60,10 @@ module ActiveRecord
 
     # Apply the touches that were delayed.
     def self.apply
-      # If we don't do this then an infinite loop is possible due to how Set#subtract and ActiveRecord::Core#== work
-      state.remove_unpersisted_records!
       begin
+        # If we don't do this then an infinite loop is possible due to how Set#subtract and ActiveRecord::Core#== work
+        state.remove_unpersisted_records!
+
         ActiveRecord::Base.transaction do
           state.records_by_attrs_and_class.each do |attr, classes_and_records|
             classes_and_records.each do |klass, records|

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -75,6 +75,7 @@ module ActiveRecord
 
     # Touch the specified records--non-empty set of instances of the same class.
     def self.touch_records(attr, klass, records)
+      state.remove_unpersisted_records!
       attributes = records.first.send(:timestamp_attributes_for_update_in_model)
       attributes << attr if attr
 
@@ -86,7 +87,7 @@ module ActiveRecord
           column = column.to_s
           changes[column] = current_time
           records.each do |record|
-            next if record.destroyed?
+            next unless record.persisted?
             record.instance_eval do
               write_attribute column, current_time
               @changed_attributes.except!(*changes.keys)

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -60,6 +60,8 @@ module ActiveRecord
 
     # Apply the touches that were delayed.
     def self.apply
+      # If we don't do this then an infinite loop is possible due to how Set#subtract and ActiveRecord::Core#== work
+      state.remove_unpersisted_records!
       begin
         ActiveRecord::Base.transaction do
           state.records_by_attrs_and_class.each do |attr, classes_and_records|
@@ -75,8 +77,6 @@ module ActiveRecord
 
     # Touch the specified records--non-empty set of instances of the same class.
     def self.touch_records(attr, klass, records)
-      # If we don't do this then an infinite loop is possible due to how Set#subtract and ActiveRecord::Core#== work
-      state.remove_unpersisted_records!
       attributes = records.first.send(:timestamp_attributes_for_update_in_model)
       attributes << attr if attr
 

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         @records.clear
         @already_updated_records.clear
       end
-      
+
       def remove_unpersisted_records!
         @records.each do |attr, set|
           set.keep_if(&:persisted?)

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -55,6 +55,7 @@ module ActiveRecord
       # which requires that the hash be rekeyed.
       def remove_unpersisted_records!
         @records.each do |attr, set|
+          set.each(&:persisted?)
           set.instance_variable_get(:@hash).rehash
           set.keep_if(&:persisted?)
           @records.delete attr if set.empty?

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -50,8 +50,8 @@ module ActiveRecord
       end
       
       def remove_unpersisted_records!
-        @records.each do |attr, records|
-          records.keep_if(&:persisted?)
+        @records.each do |attr, set|
+          set.keep_if(&:persisted?)
         end
       end
     end

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -34,8 +34,7 @@ module ActiveRecord
       end
 
       def more_records?
-        # Since an empty set is still a value we have to also check that our values are present
-        @records.present? && @records.values.all?(&:present?)
+        @records.present?
       end
 
       def add_record(record, *columns)
@@ -54,6 +53,7 @@ module ActiveRecord
         @records.each do |_, set|
           set.instance_variable_get(:@hash).rehash
           set.keep_if(&:persisted?)
+          @records.delete attr if set.empty?
         end
       end
     end

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -56,9 +56,27 @@ module ActiveRecord
       def remove_unpersisted_records!
         @records.each do |attr, set|
           set.each(&:persisted?)
-          set.instance_variable_get(:@hash).rehash
+          rehash set
           set.keep_if(&:persisted?)
-          @records.delete attr if set.empty?
+          @records.delete(attr) if set.empty?
+        end
+      end
+
+      private
+
+      # The Set class identifies uniqueness using the result of each object's #hash method.
+      # If an object is modified after added to the Set, its hash value may change, so the Set needs to be "rehashed".
+      # Prior to Ruby 2.5, Set object does not support a public api to rehash the objects in its collection,
+      # but it is publicly documented that the class uses an underlying Hash for its collection, which does support
+      # a #rehash operation.
+      # This method abstracts the difference, allowing rehashing of the set for pre-2.5 Ruby while preventing future
+      # implementations from breaking this library by changing the internal implementation of hash, preferring to rely
+      # on the now-public #reset method
+      def rehash(set)
+        if set.respond_to?(:reset)
+          set.reset
+        else
+          set.instance_variable_get(:@hash).rehash
         end
       end
     end

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       # Set#subtract and ActiveRecord::Core#== work with the in memory changes 
       # from a rollback and active record sync
       def remove_unpersisted_records!
-        @records.each do |_, set|
+        @records.each do |attr, set|
           set.instance_variable_get(:@hash).rehash
           set.keep_if(&:persisted?)
           @records.delete attr if set.empty?

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -50,8 +50,9 @@ module ActiveRecord
       end
 
       # If we don't do this then an infinite loop is possible due to how 
-      # Set#subtract and ActiveRecord::Core#== work with the in memory changes 
-      # from a rollback and active record sync
+      # Set#subtract and ActiveRecord::Core#== work internally, ActiveRecord lazily syncs
+      # transaction state after rollback, which may change in-memory state of key objects,
+      # which requires that the hash be rekeyed.
       def remove_unpersisted_records!
         @records.each do |attr, set|
           set.instance_variable_get(:@hash).rehash

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -49,6 +49,9 @@ module ActiveRecord
         @already_updated_records.clear
       end
 
+      # If we don't do this then an infinite loop is possible due to how 
+      # Set#subtract and ActiveRecord::Core#== work with the in memory changes 
+      # from a rollback and active record sync
       def remove_unpersisted_records!
         @records.each do |_, set|
           set.instance_variable_get(:@hash).rehash

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -48,7 +48,12 @@ module ActiveRecord
         @records.clear
         @already_updated_records.clear
       end
-
+      
+      def remove_unpersisted_records!
+        @records.each do |attr, records|
+          records.keep_if(&:persisted?)
+        end
+      end
     end
   end
 end

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -34,7 +34,8 @@ module ActiveRecord
       end
 
       def more_records?
-        @records.present?
+        # Since an empty set is still a value we have to also check that our values are present
+        @records.present? && @records.values.all?(&:present?)
       end
 
       def add_record(record, *columns)

--- a/lib/activerecord/delay_touching/state.rb
+++ b/lib/activerecord/delay_touching/state.rb
@@ -51,7 +51,8 @@ module ActiveRecord
       end
 
       def remove_unpersisted_records!
-        @records.each do |attr, set|
+        @records.each do |_, set|
+          set.instance_variable_get(:@hash).rehash
           set.keep_if(&:persisted?)
         end
       end


### PR DESCRIPTION
First alternative for https://github.com/godaddy/activerecord-delay_touching/pull/16

This option is as we discussed. 
The downside to this approach is that the entire set of records is iterated _at least 3 times_ at every nested level to ensure that any unpersisted records are removed from the hash. This could be very expensive for a large set of records touched in a single transaction.