### PR TITLE
WIP - delay_touching on relationship table may cause "update where NULL" query

### DIFF
--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -95,7 +95,7 @@ module ActiveRecord
           end
         end
 
-        klass.unscoped.where(klass.primary_key => records.select(&:persisted?).update_all(changes)
+        klass.unscoped.where(klass.primary_key => records.select(&:persisted?)).update_all(changes)
       end
       state.updated attr, records
       records.each { |record| record.run_callbacks(:touch) }

--- a/lib/activerecord/delay_touching.rb
+++ b/lib/activerecord/delay_touching.rb
@@ -95,7 +95,7 @@ module ActiveRecord
           end
         end
 
-        klass.unscoped.where(klass.primary_key => records).update_all(changes)
+        klass.unscoped.where(klass.primary_key => records.select(&:persisted?).update_all(changes)
       end
       state.updated attr, records
       records.each { |record| record.run_callbacks(:touch) }

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -8,6 +8,9 @@ end
 
 class Post < ActiveRecord::Base
   has_many :comments, dependent: :destroy
+
+  has_many :tag_relationships, dependent: :destroy
+  has_many :tags, through: :tag_relationships
 end
 
 class User < ActiveRecord::Base
@@ -17,4 +20,14 @@ end
 class Comment < ActiveRecord::Base
   belongs_to :post, touch: true
   belongs_to :user, touch: true
+end
+
+class Tag < ActiveRecord::Base
+  has_many :tag_relationships, dependent: :destroy
+  has_many :posts, through: :tag_relationships
+end
+
+class TagRelationship < ActiveRecord::Base
+  belongs_to :tag, touch: true
+  belongs_to :post
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -30,4 +30,12 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :tags, force: true do |t|
+    t.timestamps null: false
+  end
+
+  create_table :tag_relationships, force: true do |t|
+    t.integer :tag_id
+    t.integer :post_id
+  end
 end


### PR DESCRIPTION
This PR introduces a failing spec to replicate issue described in #19. This branch can be used as the source branch for fixes, but shouldn't be merged until specs pass.