### PR TITLE
Add Rails 5 support

### DIFF
--- a/activerecord-delay_touching.gemspec
+++ b/activerecord-delay_touching.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "activerecord", "~> 4.2"
+  spec.add_dependency             "activerecord", ">= 4.2", "< 5.3"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/activerecord/delay_touching/version.rb
+++ b/lib/activerecord/delay_touching/version.rb
@@ -1,5 +1,5 @@
 module Activerecord
   module DelayTouching
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
This PR adds Rails 5.0 support to the `activerecord-delay_touching` gem.
This PR does not break Rails 4.0 compatibility.
Rspec has passed against both latest Rails version 5.2.1 and 4.2.9.

One drawback of this implementation is it does not respect `time` in `xxx.touch(time: time)`, it will only be filled with current time.